### PR TITLE
Conditionnally apply `auto_detect_line_endings` since deprecation on PHP 8.1

### DIFF
--- a/sources/Loader.php
+++ b/sources/Loader.php
@@ -74,10 +74,21 @@ final class Loader
             throw new \Exception(sprintf(self::EXCEPTION_NO_FILE, $absolutePath));
         }
         $this->filePath = $absolutePath;
+
+        $is_php81 = (version_compare(PHP_VERSION, '8.1.0') >= 0);
+
+        // auto_detect_line_endings
         $adle_setting = "auto_detect_line_endings";
-        ini_set($adle_setting, "true");
+        if (!$is_php81) {
+          ini_set($adle_setting, "true");
+        }
+
         $content = @file($absolutePath, FILE_IGNORE_NEW_LINES);
-        ini_restore($adle_setting);
+
+        if (!$is_php81) {
+          ini_restore($adle_setting);
+        }
+
         if (is_bool($content)) {
             throw new \Exception(sprintf(self::EXCEPTION_READ_ERROR, $absolutePath));
         }


### PR DESCRIPTION
This PR fixes one deprecations reported by PHP 8.1:
-  [x] `auto_detect_line_endings` ini setting is deprecated as of 8.1

For backward compatibility, use a condition to still apply the `auto_detect_line_endings` on version lower than PHP 8.1.0 