### PR TITLE
fix php 8.1.x deprecated inherited undeclared return-type

### DIFF
--- a/sources/NodeList.php
+++ b/sources/NodeList.php
@@ -69,7 +69,7 @@ class NodeList extends \SplDoublyLinkedList
         return false;
     }
 
-    public function push($node)
+    public function push($node): void
     {
         $type = null;
         if ($node instanceof Item ) {

--- a/sources/types/YamlObject.php
+++ b/sources/types/YamlObject.php
@@ -187,7 +187,7 @@ class YamlObject extends \ArrayIterator implements \JsonSerializable
      *
      * @return mixed Array (of object properties or keys) OR string if YAML object only contains LITTERAL (in self::value)
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $prop = get_object_vars($this);
         unset($prop["__yaml__object__api"]);


### PR DESCRIPTION
This PR fixes one deprecations reported by PHP 8.1:
-  [x] Deprecated function: Return type of Dallgoot\Yaml\YamlObject::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 11 of /var/www/vendor/dallgoot/yaml/sources/types/YamlObject.php).
- [x] Deprecated function: Return type of Dallgoot\Yaml\NodeList::push($node) should either be compatible with SplDoublyLinkedList::push(mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 571 of /var/www/vendor/composer/ClassLoader.php).