### PR TITLE
Update to improve php 8.4 compatability

### DIFF
--- a/src/NodeList.php
+++ b/src/NodeList.php
@@ -33,7 +33,7 @@ class NodeList extends \SplDoublyLinkedList
      *
      * @param NodeGeneric|null $node (optional) a node that will be pushed as first element
      */
-    public function __construct(NodeGeneric $node = null)
+    public function __construct(?NodeGeneric $node = null)
     {
         // parent::__construct();
         // $this->setIteratorMode(self::IT_MODE_KEEP);

--- a/src/Nodes/Key.php
+++ b/src/Nodes/Key.php
@@ -17,7 +17,7 @@ class Key extends NodeGeneric
 {
     const ERROR_NO_KEYNAME = self::class . ": key has NO IDENTIFIER on line %d";
 
-    public function __construct(string $nodeString, int $line, array $matches = null)
+    public function __construct(string $nodeString, int $line, ?array $matches = null)
     {
         parent::__construct($nodeString, $line);
         if (is_null($matches)) {


### PR DESCRIPTION
Updated a few functions that have a default value of = null, to include the ? operator when declaring the variable in the function call.  This is now required for php 8.4.